### PR TITLE
Set up TravisCI to deploy to Github pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 node_js:
   - 8.11.2
+
 deploy:
-  provider: pages
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN
-  keep-history: true
+  provider: script
+  script: npm run deploy-storybook -- --ci
   on:
     branch: master


### PR DESCRIPTION
TravisCI raised this on pre-merge into master branches at the bottom of https://travis-ci.org/conversation/tc-assets/builds/385026757#L3308:
```Skipping a deployment with the pages provider because this branch is not permitted```

I'd originally gone down the route of the TravisCI Github pages method - https://docs.travis-ci.com/user/deployment/pages/
Unfortunately, it wouldn't deploy storybook, only the README.md. huahua

Then I tried the `after_success` hook; it worked, but deployed on every successful test run.

The script method is the ticket! For further reading:
https://docs.travis-ci.com/user/deployment/script/
