### PR TITLE
Set up TravisCI to skip cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 
 deploy:
   provider: script
+  skip-cleanup: true
   script: npm run deploy-storybook -- --ci
   on:
     branch: master


### PR DESCRIPTION
Got this error:
```
Preparing deploy
Cleaning up git repository with `git stash --all`.
If you need build artifacts for deployment, set `deploy.skip_cleanup: true`.
See https://docs.travis-ci.com/user/deployment#Uploading-Files-and-skip_cleanup.
```