### PR TITLE
Add storybook-readme to show README.md for each component as documentation

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,3 +1,4 @@
 import '@storybook/addon-links/register';
 import '@storybook/addon-options/register';
 import '@storybook/addon-actions/register';
+import 'storybook-readme/register';

--- a/Components/Button/README.md
+++ b/Components/Button/README.md
@@ -1,0 +1,15 @@
+# Button
+
+The Button is used to represent either an anchor or a button tag, and has a number of display options.
+
+## Properties
+
+ propName | propType                        | defaultValue | isRequired
+----------|---------------------------------|--------------|:----------:
+ children | Array of nodes, or a node       | undefined    | ✓
+ disabled | Boolean                         | false        |
+ href     | String                          | undefined    |
+ onClick  | Function                        | undefined    |
+ position | String of "", "left" or "right" | ""           |
+ size     | String of "large"               | undefined    |
+ type     | String of "danger" or "primary" | undefined    |

--- a/Components/Button/stories.jsx
+++ b/Components/Button/stories.jsx
@@ -7,7 +7,7 @@ import README from './README.md';
 import Button from "./index";
 
 setAddon(chaptersAddon);
-storiesOf('Button', module).add('Documentation', doc(README));
+storiesOf('Button', module).add('Overview', doc(README));
 storiesOf("Button", module).addWithChapters('Display', {
   chapters: [
     {

--- a/Components/Button/stories.jsx
+++ b/Components/Button/stories.jsx
@@ -2,17 +2,20 @@ import React from "react";
 import { storiesOf, setAddon } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import chaptersAddon from 'react-storybook-addon-chapters';
+import { doc } from 'storybook-readme';
+import README from './README.md';
 import Button from "./index";
 
 setAddon(chaptersAddon);
-
-storiesOf("Button", module).addWithChapters('Display',  {
+storiesOf('Button', module).add('Documentation', doc(README));
+storiesOf("Button", module).addWithChapters('Display', {
   chapters: [
     {
       sections: [
         {
           title: "Standard",
           info: "Indicates a neutral informative change or action.",
+          subtitle: "Default",
           sectionFn: () => (
             <Button onClick={action("Button Clicked")}>Button text</Button>
           )
@@ -57,7 +60,8 @@ storiesOf("Button", module).addWithChapters('Display',  {
     {
       sections: [
         {
-          title: "Default size",
+          title: "Regular",
+          subtitle: "Default",
           sectionFn: () => (
             <Button onClick={action("Button Clicked")}>Button text</Button>
           )

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "jest": "^23.0.1",
     "jquery": "^3.3.1",
-    "react-storybook-addon-chapters": "^2.1.5"
+    "react-storybook-addon-chapters": "^2.1.5",
+    "storybook-readme": "^3.3.0"
   }
 }


### PR DESCRIPTION
This PR adds the capability for us to document each component via a `README.md`, and fills out some more of the `<Button />` documentation.