### PR TITLE
Ensure storybook is run in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
   - 8.11.2
-before_deploy:
+script:
+  - npm test
   - npm run storybook
 deploy:
   provider: pages


### PR DESCRIPTION
We had an issue where the storybook configuration was broken, but the build was passing. If we run storybook as part of the CI step then we can never have a green build with a broken design document.

I tested this by purposefully breaking the storybook in a commit: https://travis-ci.org/conversation/tc-assets/builds/386027495