### PR TITLE
Add a SearchBox component

### DIFF
--- a/Components/SearchBox/README.md
+++ b/Components/SearchBox/README.md
@@ -1,0 +1,11 @@
+# SearchBox
+
+The SearchBox provides a text input that throttles it's `onChange` event
+which we can use to make async calls for data.
+
+## Properties
+
+ propName    | propType | defaultValue | isRequired
+-------------|----------|--------------|:----------:
+ placeholder | String   | ""           |
+ onChange    | Function |              | ✓

--- a/Components/SearchBox/index.jsx
+++ b/Components/SearchBox/index.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { throttle } from "underscore";
+import styles from "./styles.css";
+
+export default class SearchBox extends React.Component {
+  static submit(e) {
+    e.preventDefault();
+  }
+
+  constructor(props) {
+    super(props);
+    this.throttledNotify = throttle(this.notifySearchChanged, 500, { leading: false });
+    this.keyup = this.keyup.bind(this);
+  }
+
+  keyup(e) {
+    this.throttledNotify(e.target.value);
+  }
+
+  notifySearchChanged(search) {
+    this.props.onChange(search);
+  }
+
+  render() {
+    return (
+      <form onSubmit={SearchBox.submit}>
+        <input
+          type="text"
+          name="q"
+          onKeyUp={this.keyup}
+          placeholder={this.props.placeholder}
+          className={styles.input}
+        />
+      </form>
+    );
+  }
+}
+
+SearchBox.defaultProps = {
+  placeholder: "",
+};
+
+SearchBox.propTypes = {
+  placeholder: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+};

--- a/Components/SearchBox/index.jsx
+++ b/Components/SearchBox/index.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { throttle } from "underscore";
+import { throttle } from "lodash";
 import styles from "./styles.css";
 
 export default class SearchBox extends React.Component {

--- a/Components/SearchBox/spec.jsx
+++ b/Components/SearchBox/spec.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { shallow } from "enzyme";
+import SearchBox from "./index";
+
+jest.useFakeTimers();
+
+describe("<SearchBox />", () => {
+  test("renders the placeholder", () => {
+    const filterSearch = shallow(<SearchBox placeholder="foo" onChange={() => {}} />);
+    expect(filterSearch.find("input").prop("placeholder")).toBe("foo");
+  });
+
+  describe("onChange callback", () => {
+    const e = { target: { value: "foo" } };
+
+    test("executes the callback on keyup", (done) => {
+      const callback = (value) => {
+        expect(value).toEqual("foo");
+        done();
+      };
+      const filterSearch = shallow(<SearchBox onChange={callback} />);
+      filterSearch.find("input").simulate("keyup", e);
+      jest.runAllTimers();
+    });
+
+    test("throttles the callback", () => {
+      const callback = jest.fn();
+      const filterSearch = shallow(<SearchBox onChange={callback} />);
+      filterSearch.find("input").simulate("keyup", e);
+      filterSearch.find("input").simulate("keyup", e);
+      jest.runAllTimers();
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/Components/SearchBox/stories.jsx
+++ b/Components/SearchBox/stories.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { doc } from 'storybook-readme';
+import README from './README.md';
+import SearchBox from "./index";
+
+storiesOf('SearchBox', module).add('Overview', doc(README));
+storiesOf("SearchBox", module).addWithChapters('Display',  {
+  chapters: [
+    {
+      sections: [
+        {
+          title: "Default",
+          info: "The default SearchBox provides a throttled onChange callback",
+          sectionFn: () => (
+            <SearchBox onChange={action("Throttled search term")} />
+          )
+        }, {
+          title: "With placeholder",
+          info: "SearchBox can also show an optional placeholder text",
+          sectionFn: () => (
+            <SearchBox placeholder="Search for?" onChange={action("Throttled search term")} />
+          )
+        }
+      ]
+    }
+  ]
+});

--- a/Components/SearchBox/styles.css
+++ b/Components/SearchBox/styles.css
@@ -1,0 +1,7 @@
+:local .input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 4px 8px;
+  font-size: 12px;
+  border: 1px solid #ccc;
+}


### PR DESCRIPTION
This component was lifted from TC where we're using it on `editorial/institutions#index`.

It's provides a styled text input field that runs 100% of it's parent, and throttles it's `onChange` event which we can use to make async calls (like up searching for institutions, etc).